### PR TITLE
T30015 Added cql_mintimeuuid and cql_maxtimeuuid operators

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    query_builder (0.0.5.ep)
+    query_builder (0.0.6.ep)
       equalizer (~> 0.0.11)
       immutability (~> 0.0.2)
       transproc (~> 0.4.0)

--- a/lib/query_builder/cql/operators/cql_gt.rb
+++ b/lib/query_builder/cql/operators/cql_gt.rb
@@ -20,7 +20,7 @@ module QueryBuilder::CQL::Operators
   #   # => "foo > MINTIMEUUID('2021-03-25 00:00:00')"
   #
   # @param [#to_s] column
-  # @param [Transproc::Function || Numeric] argument
+  # @param [Transproc::Function, Numeric] argument
   #
   # @return [String]
   #

--- a/lib/query_builder/cql/operators/cql_gt.rb
+++ b/lib/query_builder/cql/operators/cql_gt.rb
@@ -11,13 +11,21 @@ module QueryBuilder::CQL::Operators
   #   fn[:foo]
   #   # => "foo > 3"
   #
+  # It also support nested CQL function calls
+  #
+  # @example
+  #   cql_fn = Operators[:cql_mintimeuuid, "2021-03-25 00:00:00 +0000"]
+  #   fn = Operators[:cql_gt, cql_fn]
+  #   fn[:foo]
+  #   # => "foo > MINTIMEUUID('2021-03-25 00:00:00')"
+  #
   # @param [#to_s] column
-  # @param [Numeric] value
+  # @param [Transproc::Function || Numeric] argument
   #
   # @return [String]
   #
-  def self.cql_gt(column, value)
-    "#{column} > #{cql_literal(value)}"
+  def self.cql_gt(column, argument)
+    "#{column} > #{argument.instance_of?(Transproc::Function) ? argument.call : cql_literal(argument)}"
   end
 
 end # module QueryBuilder::CQL::Operators

--- a/lib/query_builder/cql/operators/cql_gte.rb
+++ b/lib/query_builder/cql/operators/cql_gte.rb
@@ -20,7 +20,7 @@ module QueryBuilder::CQL::Operators
   #   # => "foo >= MINTIMEUUID('2021-03-25 00:00:00')"
   #
   # @param [#to_s] column
-  # @param [Transproc::Function || Numeric] argument
+  # @param [Transproc::Function, Numeric] argument
   #
   # @return [String]
   #

--- a/lib/query_builder/cql/operators/cql_gte.rb
+++ b/lib/query_builder/cql/operators/cql_gte.rb
@@ -11,13 +11,21 @@ module QueryBuilder::CQL::Operators
   #   fn[:foo]
   #   # => "foo >= 3"
   #
+  # It also support nested CQL function calls
+  #
+  # @example
+  #   cql_fn = Operators[:cql_mintimeuuid, "2021-03-25 00:00:00 +0000"]
+  #   fn = Operators[:cql_gte, cql_fn]
+  #   fn[:foo]
+  #   # => "foo >= MINTIMEUUID('2021-03-25 00:00:00')"
+  #
   # @param [#to_s] column
-  # @param [Numeric] value
+  # @param [Transproc::Function || Numeric] argument
   #
   # @return [String]
   #
-  def self.cql_gte(column, value)
-    "#{column} >= #{cql_literal(value)}"
+  def self.cql_gte(column, argument)
+    "#{column} >= #{argument.instance_of?(Transproc::Function) ? argument.call : cql_literal(argument)}"
   end
 
 end # module QueryBuilder::CQL::Operators

--- a/lib/query_builder/cql/operators/cql_lt.rb
+++ b/lib/query_builder/cql/operators/cql_lt.rb
@@ -11,13 +11,21 @@ module QueryBuilder::CQL::Operators
   #   fn[:foo]
   #   # => "foo < 3"
   #
+  # It also support nested CQL function calls
+  #
+  # @example
+  #   cql_fn = Operators[:cql_mintimeuuid, "2021-03-25 00:00:00 +0000"]
+  #   fn = Operators[:cql_lt, cql_fn]
+  #   fn[:foo]
+  #   # => "foo < MINTIMEUUID('2021-03-25 00:00:00')"
+  #
   # @param [#to_s] column
-  # @param [Numeric] value
+  # @param [Transproc::Function || Numeric] argument
   #
   # @return [String]
   #
-  def self.cql_lt(column, value)
-    "#{column} < #{cql_literal(value)}"
+  def self.cql_lt(column, argument)
+    "#{column} < #{argument.instance_of?(Transproc::Function) ? argument.call : cql_literal(argument)}"
   end
 
 end # module QueryBuilder::CQL::Operators

--- a/lib/query_builder/cql/operators/cql_lt.rb
+++ b/lib/query_builder/cql/operators/cql_lt.rb
@@ -20,7 +20,7 @@ module QueryBuilder::CQL::Operators
   #   # => "foo < MINTIMEUUID('2021-03-25 00:00:00')"
   #
   # @param [#to_s] column
-  # @param [Transproc::Function || Numeric] argument
+  # @param [Transproc::Function, Numeric] argument
   #
   # @return [String]
   #

--- a/lib/query_builder/cql/operators/cql_lte.rb
+++ b/lib/query_builder/cql/operators/cql_lte.rb
@@ -20,7 +20,7 @@ module QueryBuilder::CQL::Operators
   #   # => "foo <= MINTIMEUUID('2021-03-25 00:00:00')"
   #
   # @param [#to_s] column
-  # @param [Transproc::Function || Numeric] argument
+  # @param [Transproc::Function, Numeric] argument
   #
   # @return [String]
   #

--- a/lib/query_builder/cql/operators/cql_lte.rb
+++ b/lib/query_builder/cql/operators/cql_lte.rb
@@ -11,13 +11,21 @@ module QueryBuilder::CQL::Operators
   #   fn[:foo]
   #   # => "foo <= 3"
   #
+  # It also support nested CQL function calls
+  #
+  # @example
+  #   cql_fn = Operators[:cql_mintimeuuid, "2021-03-25 00:00:00 +0000"]
+  #   fn = Operators[:cql_lt, cql_fn]
+  #   fn[:foo]
+  #   # => "foo <= MINTIMEUUID('2021-03-25 00:00:00')"
+  #
   # @param [#to_s] column
-  # @param [Numeric] value
+  # @param [Transproc::Function || Numeric] argument
   #
   # @return [String]
   #
-  def self.cql_lte(column, value)
-    "#{column} <= #{cql_literal(value)}"
+  def self.cql_lte(column, argument)
+    "#{column} <= #{argument.instance_of?(Transproc::Function) ? argument.call : cql_literal(argument)}"
   end
 
 end # module QueryBuilder::CQL::Operators

--- a/lib/query_builder/cql/operators/cql_maxtimeuuid.rb
+++ b/lib/query_builder/cql/operators/cql_maxtimeuuid.rb
@@ -4,7 +4,7 @@
 
  module QueryBuilder::CQL::Operators
 
-   # Returns value of CQL MAXTIMEUUID
+   # Returns the CQL MAXTIMEUUID() definition
    #
    # @example
    #   fn = Operators[:cql_maxtimeuuid]

--- a/lib/query_builder/cql/operators/cql_maxtimeuuid.rb
+++ b/lib/query_builder/cql/operators/cql_maxtimeuuid.rb
@@ -1,0 +1,23 @@
+ # encoding: utf-8
+
+ require_relative "cql_literal"
+
+ module QueryBuilder::CQL::Operators
+
+   # Returns value of CQL MAXTIMEUUID
+   #
+   # @example
+   #   fn = Operators[:cql_maxtimeuuid]
+   #
+   #   fn[:string_timestamp]
+   #   # => "MAXTIMEUUID('2013-02-02 10:00+0000')"
+   #
+   # @param [#to_s] value
+   #
+   # @return [String]
+   #
+   def self.cql_maxtimeuuid(value)
+     "MAXTIMEUUID(#{cql_literal(value)})"
+   end
+
+ end # module QueryBuilder::CQL::Operators

--- a/lib/query_builder/cql/operators/cql_mintimeuuid.rb
+++ b/lib/query_builder/cql/operators/cql_mintimeuuid.rb
@@ -1,0 +1,23 @@
+ # encoding: utf-8
+
+ require_relative "cql_literal"
+
+ module QueryBuilder::CQL::Operators
+
+   # Returns value of CQL MINTIMEUUID
+   #
+   # @example
+   #   fn = Operators[:cql_mintimeuuid]
+   #
+   #   fn[:string_timestamp]
+   #   # => "MINTIMEUUID('2013-02-02 10:00+0000')"
+   #
+   # @param [#to_s] value
+   #
+   # @return [String]
+   #
+   def self.cql_mintimeuuid(value)
+     "MINTIMEUUID(#{cql_literal(value)})"
+   end
+
+ end # module QueryBuilder::CQL::Operators

--- a/lib/query_builder/cql/operators/cql_mintimeuuid.rb
+++ b/lib/query_builder/cql/operators/cql_mintimeuuid.rb
@@ -4,7 +4,7 @@
 
  module QueryBuilder::CQL::Operators
 
-   # Returns value of CQL MINTIMEUUID
+   # Returns the CQL MINTIMEUUID() definition
    #
    # @example
    #   fn = Operators[:cql_mintimeuuid]

--- a/lib/query_builder/version.rb
+++ b/lib/query_builder/version.rb
@@ -5,6 +5,6 @@ module QueryBuilder
 
   # The semantic version of the module.
   # @see http://semver.org/ Semantic versioning 2.0
-  VERSION = "0.0.5.ep".freeze
+  VERSION = "0.0.6.ep".freeze
 
 end # module QueryBuilder

--- a/spec/integration/select_spec.rb
+++ b/spec/integration/select_spec.rb
@@ -41,6 +41,17 @@ describe "SELECT" do
     end
 
     let(:cql) { "SELECT DISTINCT uuid AS id, name FROM wildlife.species WHERE id >= 3 AND id < 10 AND area IN ('park', 'garden') AND names[1] = 'cat' ORDER BY name DESC LIMIT 10 ALLOW FILTERING;" }
+
+  end
+
+  it_behaves_like :query_builder do
+    subject do
+      table
+        .select
+        .where(uuid: cql_lt(cql_mintimeuuid("2013-02-02 10:00+0000")))
+    end
+
+    let(:cql) { "SELECT * FROM wildlife.species WHERE uuid < MINTIMEUUID('2013-02-02 10:00+0000');" }
   end
 
 end # describe SELECT

--- a/spec/unit/cql/operators/cql_gt_spec.rb
+++ b/spec/unit/cql/operators/cql_gt_spec.rb
@@ -16,4 +16,12 @@ describe QueryBuilder::CQL::Operators, ".cql_gt" do
     let(:output) { "foo > 'bar'" }
   end
 
+  it_behaves_like :transforming_immutable_data do
+    let(:cql_function) { QueryBuilder::CQL::Operators[:cql_mintimeuuid, "2021-03-25 00:00:00 +0000"] }
+    let(:arguments) { [:cql_gt, cql_function] }
+
+    let(:input)  { :foo }
+    let(:output) { "foo > MINTIMEUUID('2021-03-25 00:00:00 +0000')" }
+  end
+
 end # describe QueryBuilder::CQL::Operators.cql_gt

--- a/spec/unit/cql/operators/cql_gte_spec.rb
+++ b/spec/unit/cql/operators/cql_gte_spec.rb
@@ -16,4 +16,12 @@ describe QueryBuilder::CQL::Operators, ".cql_gte" do
     let(:output) { "foo >= 'bar'" }
   end
 
+  it_behaves_like :transforming_immutable_data do
+    let(:cql_function) { QueryBuilder::CQL::Operators[:cql_mintimeuuid, "2021-03-25 00:00:00 +0000"] }
+    let(:arguments) { [:cql_gte, cql_function] }
+
+    let(:input)  { :foo }
+    let(:output) { "foo >= MINTIMEUUID('2021-03-25 00:00:00 +0000')" }
+  end
+
 end # describe QueryBuilder::CQL::Operators.cql_gte

--- a/spec/unit/cql/operators/cql_lt_spec.rb
+++ b/spec/unit/cql/operators/cql_lt_spec.rb
@@ -16,4 +16,12 @@ describe QueryBuilder::CQL::Operators, ".cql_lt" do
     let(:output) { "foo < 'bar'" }
   end
 
+  it_behaves_like :transforming_immutable_data do
+    let(:cql_function) { QueryBuilder::CQL::Operators[:cql_mintimeuuid, "2021-03-25 00:00:00 +0000"] }
+    let(:arguments) { [:cql_lt, cql_function] }
+
+    let(:input)  { :foo }
+    let(:output) { "foo < MINTIMEUUID('2021-03-25 00:00:00 +0000')" }
+  end
+
 end # describe QueryBuilder::CQL::Operators.cql_lt

--- a/spec/unit/cql/operators/cql_lte_spec.rb
+++ b/spec/unit/cql/operators/cql_lte_spec.rb
@@ -16,4 +16,12 @@ describe QueryBuilder::CQL::Operators, ".cql_lte" do
     let(:output) { "foo <= 'bar'" }
   end
 
+  it_behaves_like :transforming_immutable_data do
+    let(:cql_function) { QueryBuilder::CQL::Operators[:cql_mintimeuuid, "2021-03-25 00:00:00 +0000"] }
+    let(:arguments) { [:cql_lte, cql_function] }
+
+    let(:input)  { :foo }
+    let(:output) { "foo <= MINTIMEUUID('2021-03-25 00:00:00 +0000')" }
+  end
+
 end # describe QueryBuilder::CQL::Operators.cql_lte

--- a/spec/unit/cql/operators/cql_maxtimeuuid_spec.rb
+++ b/spec/unit/cql/operators/cql_maxtimeuuid_spec.rb
@@ -1,0 +1,13 @@
+ # encoding: utf-8
+
+ describe QueryBuilder::CQL::Operators, ".cql_maxtimeuuid" do
+
+   let(:arguments) { [:cql_maxtimeuuid] }
+   let(:timestamp) { Time.new("2013-02-02 10:00+0000")  }
+
+   it_behaves_like :transforming_immutable_data do
+     let(:input)  { timestamp.to_s }
+     let(:output) { "MAXTIMEUUID('#{input}')" }
+   end
+
+ end # describe QueryBuilder::CQL::Operators.cql_maxtimeuuid

--- a/spec/unit/cql/operators/cql_maxtimeuuid_spec.rb
+++ b/spec/unit/cql/operators/cql_maxtimeuuid_spec.rb
@@ -3,7 +3,7 @@
  describe QueryBuilder::CQL::Operators, ".cql_maxtimeuuid" do
 
    let(:arguments) { [:cql_maxtimeuuid] }
-   let(:timestamp) { Time.new("2013-02-02 10:00+0000")  }
+   let(:timestamp) { Time.new("2013-02-02 10:00:00 +0000")  }
 
    it_behaves_like :transforming_immutable_data do
      let(:input)  { timestamp.to_s }

--- a/spec/unit/cql/operators/cql_mintimeuuid_spec.rb
+++ b/spec/unit/cql/operators/cql_mintimeuuid_spec.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+
+describe QueryBuilder::CQL::Operators, ".cql_mintimeuuid" do
+
+  let(:arguments) { [:cql_mintimeuuid] }
+  let(:timestamp) { Time.new("2013-02-02 10:00+0000")  }
+
+  it_behaves_like :transforming_immutable_data do
+    let(:input)  { timestamp.to_s }
+    let(:output) { "MINTIMEUUID('#{input}')" }
+  end
+
+end # describe QueryBuilder::CQL::Operators.cql_mintimeuuid

--- a/spec/unit/cql/operators/cql_mintimeuuid_spec.rb
+++ b/spec/unit/cql/operators/cql_mintimeuuid_spec.rb
@@ -3,7 +3,7 @@
 describe QueryBuilder::CQL::Operators, ".cql_mintimeuuid" do
 
   let(:arguments) { [:cql_mintimeuuid] }
-  let(:timestamp) { Time.new("2013-02-02 10:00+0000")  }
+  let(:timestamp) { Time.new("2013-02-02 10:00:00 +0000")  }
 
   it_behaves_like :transforming_immutable_data do
     let(:input)  { timestamp.to_s }


### PR DESCRIPTION
Also included in this change, `cql_gt`, `cql_gte`, `cql_lt` and `cql_lte` now support receiving a CQL operator as argument, not only literals